### PR TITLE
CollectionsPlume: remove unneeded @SuppressWarnings

### DIFF
--- a/src/main/java/org/plumelib/util/CollectionsPlume.java
+++ b/src/main/java/org/plumelib/util/CollectionsPlume.java
@@ -618,7 +618,7 @@ public final class CollectionsPlume {
    * @param orig a collection
    * @return a copy of {@code orig}, as described above
    */
-  @SuppressWarnings({"signedness", "nullness:argument"}) // problem with clone()
+  @SuppressWarnings("nullness:argument") // problem with clone()
   public static <T extends @Nullable DeepCopyable<T>, C extends @Nullable Collection<T>>
       @PolyNull C deepCopy(@PolyNull C orig) {
     if (orig == null) {
@@ -897,7 +897,6 @@ public final class CollectionsPlume {
    * @return true if the second list is a subsequence (not necessarily contiguous) of the first
    */
   // TODO: This could take as input a RandomAccess.
-  @SuppressWarnings("signedness")
   public static <T> boolean isSubsequenceMaybeNonContiguous(
       Iterable<T> longer, Iterable<T> shorter) {
     Iterator<T> itorLonger = longer.iterator();
@@ -1932,7 +1931,7 @@ public final class CollectionsPlume {
    * @return a copy of {@code orig}, as described above
    * @deprecated use {@link MapsP#deepCopy}
    */
-  @SuppressWarnings({"nullness", "signedness"}) // generics problem with clone
+  @SuppressWarnings("nullness") // generics problem with clone
   @Deprecated // 2025-06-28
   public static <
           K extends @Nullable DeepCopyable<K>,
@@ -1964,7 +1963,7 @@ public final class CollectionsPlume {
    * @return a copy of {@code orig}, as described above
    * @deprecated use {@link MapsP#deepCopyValues}
    */
-  @SuppressWarnings({"nullness", "signedness"}) // generics problem with clone
+  @SuppressWarnings("nullness") // generics problem with clone
   @Deprecated // 2025-06-28
   public static <K, V extends @Nullable DeepCopyable<V>, M extends @Nullable Map<K, V>>
       @PolyNull M deepCopyValues(@PolyNull M orig) {
@@ -2022,7 +2021,6 @@ public final class CollectionsPlume {
    * @return a copy of {@code orig}, as described above
    * @deprecated use {@link MapsP#cloneElements}
    */
-  @SuppressWarnings({"nullness", "signedness"}) // generics problem with clone
   @Deprecated // 2025-06-28
   public static <K, V, M extends @Nullable Map<K, V>> @PolyNull M cloneElements(@PolyNull M orig) {
     return cloneElements(orig, true);
@@ -2039,7 +2037,6 @@ public final class CollectionsPlume {
    * @return a copy of {@code orig}, as described above
    * @deprecated use {@link MapsP#cloneValues}
    */
-  @SuppressWarnings({"nullness", "signedness"}) // generics problem with clone
   @Deprecated // 2025-06-28
   public static <K, V, M extends @Nullable Map<K, V>> @PolyNull M cloneValues(@PolyNull M orig) {
     return cloneElements(orig, false);


### PR DESCRIPTION
A checker-framework fix (eisop/checker-framework#1908) corrected
`-AwarnUnneededSuppressions` to actually report a bare-prefix suppression
(e.g. `"signedness"`) that suppresses nothing, instead of silently
suppressing the report about itself. Under the corrected behavior, these
suppressions in `CollectionsPlume` no longer suppress anything real:

- `deepCopy(Collection)`: `"signedness"` (kept `"nullness:argument"`).
- `isSubsequenceMaybeNonContiguous`: `"signedness"` (the whole annotation).
- `deepCopy(Map)`/`deepCopyValues`: `"signedness"` (kept `"nullness"`).
- `cloneElements(M)`/`cloneValues(M)`: `"nullness"` and `"signedness"`
  (the whole annotation) — both just delegate to the private
  `cloneElements(orig, boolean)` worker, which keeps its own suppression.

This is needed for `eisop/checker-framework`'s `plume-lib` CI job to pass
once #1908 lands there, since it currently fails with `-Werror` on the
newly (and correctly) surfaced warnings.
