### PR TITLE
MPair, IPair, MapsP, and others: remove unneeded @SuppressWarnings

### DIFF
--- a/src/main/java/org/plumelib/util/ArrayMap.java
+++ b/src/main/java/org/plumelib/util/ArrayMap.java
@@ -137,7 +137,6 @@ public class ArrayMap<K extends @UnknownSignedness Object, V extends @UnknownSig
    * @param values the values
    * @param size the number of used items in the arrays; may be less than their lengths
    */
-  @SuppressWarnings("samelen:assignment") // initialization
   @SideEffectFree
   private ArrayMap(
       K @SameLen("values") [] keys,
@@ -526,7 +525,6 @@ public class ArrayMap<K extends @UnknownSignedness Object, V extends @UnknownSig
       return removeIndex(index);
     }
 
-    @SuppressWarnings({"nullness:return"}) // array isn't padded with null, before index `size`
     @SideEffectFree
     @Override
     public @PolySigned Object[] toArray() {

--- a/src/main/java/org/plumelib/util/ClassDeterministic.java
+++ b/src/main/java/org/plumelib/util/ClassDeterministic.java
@@ -76,7 +76,6 @@ public final class ClassDeterministic {
    * @param c the Class whose enum constants to return
    * @return the class's enum constants, or null if the argument is not an enum class
    */
-  @SuppressWarnings("signedness") // ToStringComparator problem
   public static <@Interned T> T @Nullable [] getEnumConstants(Class<T> c) {
     @NonNull T[] result = c.getEnumConstants();
     if (result == null) {

--- a/src/main/java/org/plumelib/util/EntryReader.java
+++ b/src/main/java/org/plumelib/util/EntryReader.java
@@ -466,7 +466,6 @@ public class EntryReader extends LineNumberReader implements Iterable<String>, I
    * @deprecated use {@link #EntryReader(Reader,String,EntryFormat,String,String)}
    */
   @Deprecated // 2026-01-21
-  @SuppressWarnings("builder") // storing into a collection
   public @MustCallAlias EntryReader(
       @MustCallAlias Reader reader,
       String filename,
@@ -493,7 +492,6 @@ public class EntryReader extends LineNumberReader implements Iterable<String>, I
    * @deprecated use {@link #EntryReader(Reader,String,EntryFormat,String,String)}
    */
   @Deprecated // 2026-01-05
-  @SuppressWarnings("builder") // storing into a collection
   public @MustCallAlias EntryReader(
       @MustCallAlias Reader reader,
       String filename,

--- a/src/main/java/org/plumelib/util/IPair.java
+++ b/src/main/java/org/plumelib/util/IPair.java
@@ -63,7 +63,6 @@ public final class IPair<V1, V2> {
    * @return a copy of {@code orig}, with all elements cloned
    */
   // This method is static so that the pair element types can be constrained to be Cloneable.
-  @SuppressWarnings("nullness") // generics problem with deepCopy()
   public static <T1 extends Cloneable, T2 extends Cloneable> IPair<T1, T2> cloneElements(
       IPair<T1, T2> orig) {
     T1 oldFirst = orig.first;
@@ -82,7 +81,6 @@ public final class IPair<V1, V2> {
    * @param orig a pair
    * @return a deep copy of {@code orig}
    */
-  @SuppressWarnings("nullness") // generics problem with deepCopy()
   // This method is static so that the pair element types can be constrained to be DeepCopyable.
   public static <T1 extends DeepCopyable<T1>, T2 extends DeepCopyable<T2>> IPair<T1, T2> deepCopy(
       IPair<T1, T2> orig) {
@@ -99,7 +97,6 @@ public final class IPair<V1, V2> {
    * @param orig a pair
    * @return a copy of {@code orig}, where the first element is a deep copy
    */
-  @SuppressWarnings("nullness") // generics problem with deepCopy()
   public static <T1 extends DeepCopyable<T1>, T2> IPair<T1, T2> deepCopyFirst(IPair<T1, T2> orig) {
     return of(DeepCopyable.deepCopyOrNull(orig.first), orig.second);
   }
@@ -114,7 +111,6 @@ public final class IPair<V1, V2> {
    * @param orig a pair
    * @return a copy of {@code orig}, where the second element is a deep copy
    */
-  @SuppressWarnings("nullness") // generics problem with deepCopy()
   public static <T1, T2 extends DeepCopyable<T2>> IPair<T1, T2> deepCopySecond(IPair<T1, T2> orig) {
     return of(orig.first, DeepCopyable.deepCopyOrNull(orig.second));
   }

--- a/src/main/java/org/plumelib/util/MPair.java
+++ b/src/main/java/org/plumelib/util/MPair.java
@@ -58,7 +58,6 @@ public final class MPair<V1, V2> {
    * @return a copy of {@code orig}, with all elements cloned
    */
   // This method is static so that the pair element types can be constrained to be Cloneable.
-  @SuppressWarnings("nullness") // generics problem with deepCopy()
   public static <T1 extends Cloneable, T2 extends Cloneable> MPair<T1, T2> cloneElements(
       MPair<T1, T2> orig) {
     T1 oldFirst = orig.first;
@@ -77,7 +76,6 @@ public final class MPair<V1, V2> {
    * @param orig a pair
    * @return a deep copy of {@code orig}
    */
-  @SuppressWarnings("nullness") // generics problem with deepCopy()
   // This method is static so that the pair element types can be constrained to be DeepCopyable.
   public static <T1 extends DeepCopyable<T1>, T2 extends DeepCopyable<T2>> MPair<T1, T2> deepCopy(
       MPair<T1, T2> orig) {
@@ -94,7 +92,6 @@ public final class MPair<V1, V2> {
    * @param orig a pair
    * @return a copy of {@code orig}, where the first element is a deep copy
    */
-  @SuppressWarnings("nullness") // generics problem with deepCopy()
   public static <T1 extends DeepCopyable<T1>, T2> MPair<T1, T2> deepCopyFirst(MPair<T1, T2> orig) {
     return of(DeepCopyable.deepCopyOrNull(orig.first), orig.second);
   }
@@ -109,7 +106,6 @@ public final class MPair<V1, V2> {
    * @param orig a pair
    * @return a copy of {@code orig}, where the second element is a deep copy
    */
-  @SuppressWarnings("nullness") // generics problem with deepCopy()
   public static <T1, T2 extends DeepCopyable<T2>> MPair<T1, T2> deepCopySecond(MPair<T1, T2> orig) {
     return of(orig.first, DeepCopyable.deepCopyOrNull(orig.second));
   }

--- a/src/main/java/org/plumelib/util/MapsP.java
+++ b/src/main/java/org/plumelib/util/MapsP.java
@@ -155,7 +155,7 @@ public final class MapsP {
    * @param orig a map
    * @return a copy of {@code orig}, as described above
    */
-  @SuppressWarnings({"nullness", "signedness"}) // generics problem with clone
+  @SuppressWarnings("nullness") // generics problem with clone
   public static <
           K extends @Nullable DeepCopyable<K>,
           V extends @Nullable DeepCopyable<V>,
@@ -185,7 +185,7 @@ public final class MapsP {
    * @param orig a map
    * @return a copy of {@code orig}, as described above
    */
-  @SuppressWarnings({"nullness", "signedness"}) // generics problem with clone
+  @SuppressWarnings("nullness") // generics problem with clone
   public static <K, V extends @Nullable DeepCopyable<V>, M extends @Nullable Map<K, V>>
       @PolyNull M deepCopyValues(@PolyNull M orig) {
     if (orig == null) {
@@ -239,7 +239,6 @@ public final class MapsP {
    * @param orig a map
    * @return a copy of {@code orig}, as described above
    */
-  @SuppressWarnings({"nullness", "signedness"}) // generics problem with clone
   public static <K, V, M extends @Nullable Map<K, V>> @PolyNull M cloneElements(@PolyNull M orig) {
     return cloneElements(orig, true);
   }
@@ -254,7 +253,6 @@ public final class MapsP {
    * @param orig a map
    * @return a copy of {@code orig}, as described above
    */
-  @SuppressWarnings({"nullness", "signedness"}) // generics problem with clone
   public static <K, V, M extends @Nullable Map<K, V>> @PolyNull M cloneValues(@PolyNull M orig) {
     return cloneElements(orig, false);
   }

--- a/src/main/java/org/plumelib/util/UtilPlume.java
+++ b/src/main/java/org/plumelib/util/UtilPlume.java
@@ -174,7 +174,6 @@ public final class UtilPlume {
   // @InlineMe(
   //     replacement = "CollectionsPlume.intersectionCardinality(a, b, c)",
   //     imports = "org.plumelib.util.CollectionsPlume")
-  @SuppressWarnings({"lock"}) // side effect to local state (BitSet)
   @Pure
   public static int intersectionCardinality(BitSet a, BitSet b, BitSet c) {
     return CollectionsPlume.intersectionCardinality(a, b, c);
@@ -651,7 +650,6 @@ public final class UtilPlume {
   // @InlineMe(
   //     replacement = "FilesPlume.equalFiles(file1, file2, trimLines)",
   //     imports = "org.plumelib.util.FilesPlume")
-  @SuppressWarnings({"lock"}) // reads files, side effects local state
   @Pure
   public static boolean equalFiles(String file1, String file2, boolean trimLines) {
     return FilesPlume.equalFiles(file1, file2, trimLines);

--- a/src/test/java/org/plumelib/util/ArrayMapTestNayuki.java
+++ b/src/test/java/org/plumelib/util/ArrayMapTestNayuki.java
@@ -34,10 +34,7 @@ import java.util.Map;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings({
-  "nullness", // Should be removed after CF 3.12.1 is released.
-  "PMD", // Third-party-derived test code.
-})
+@SuppressWarnings("PMD") // Third-party-derived test code.
 final class ArrayMapTestNayuki {
 
   /* Utilities */


### PR DESCRIPTION
Same root cause as #239 (checker-framework's `-AwarnUnneededSuppressions` fix, eisop/checker-framework#1908): these bare-prefix (and, in `ArrayMap.java`, message-key-qualified but redundant-with-an-enclosing-bare-prefix) suppressions no longer suppress anything real under the corrected behavior.

#239 and this branch's original commit only covered the files that happened to appear in checker-framework CI's `-Werror`-truncated logs, which stop at the first failure and never show the rest. To get a complete picture in one pass, I built a local copy of eisop/checker-framework#1908's fix and ran this project's full `compileJava`/`compileTestJava` with `-Werror` temporarily removed (not committed), which reports every warning instead of stopping at the first.

## Files fixed in this commit

- `UtilPlume.java` — two unneeded `"lock"` suppressions.
- `IPair.java` — the same four-method pattern as `MPair.java` (this branch's first commit), all fully unneeded.
- `MapsP.java` — the same `deepCopy`/`deepCopyValues`/`cloneElements`/`cloneValues` pattern as `CollectionsPlume.java` (#239): `"signedness"` only on the two `deepCopy*` methods, both keys on the two `clone*` methods (which delegate to a private worker that keeps its own suppression, untouched).
- `EntryReader.java` — two (of four) `"builder"` suppressions on deprecated constructors; the other two are still needed and were left alone.
- `ClassDeterministic.java` — one unneeded `"signedness"`.
- `ArrayMap.java` — two message-key-qualified suppressions (`"samelen:assignment"`, `"nullness:return"`) redundant with the class's own bare-prefix `@SuppressWarnings({"index", "keyfor", "lock", "nullness"})`. The enclosing class-level suppression was also swallowing the `unneeded.suppression` report about these unrelated inner suppressions before the checker-framework fix, not just about itself — that's a broader (and more clearly correct) effect of the fix than "only affects reports about itself."
- `ArrayMapTestNayuki.java` (test source) — one unneeded `"nullness"`, already marked "Should be removed after CF 3.12.1 is released"; kept the unrelated `"PMD"` suppression.

## Testing

`./gradlew compileJava compileTestJava` against a local build of the checker-framework fix, with `-Werror` restored, succeeds with zero warnings — confirmed clean across the whole project, not just the files CI happened to show.

This is needed for `eisop/checker-framework`'s `plume-lib` CI job to fully pass.
